### PR TITLE
Open tab instead of window during extension registration in KeePass.

### DIFF
--- a/background/kprpcClient.ts
+++ b/background/kprpcClient.ts
@@ -398,12 +398,9 @@ class kprpcClient {
         browser.runtime.onMessage.addListener(handleMessage);
 
         const createData = {
-            type: "popup",
-            url: "/dialogs/SRP.html",
-            width: 700,
-            height: 550
+            url: "/dialogs/SRP.html"
         };
-        const creating = (browser as any).windows.create(createData);
+        const creating = (browser as any).tabs.create(createData);
     }
 
     identifyToClient (password, s, B) {

--- a/background/kprpcClient.ts
+++ b/background/kprpcClient.ts
@@ -398,12 +398,9 @@ class kprpcClient {
         browser.runtime.onMessage.addListener(handleMessage);
 
         const createData = {
-                        type: "popup",
-                        url: "/dialogs/SRP.html",
-                        width: 700,
-                        height: 550
-                     };
-        const creating = (browser as any).windows.create(createData);
+            url: "/dialogs/SRP.html"
+        };
+        const creating = (browser as any).tabs.create(createData);
     }
 
     identifyToClient (password, s, B) {

--- a/background/kprpcClient.ts
+++ b/background/kprpcClient.ts
@@ -398,9 +398,12 @@ class kprpcClient {
         browser.runtime.onMessage.addListener(handleMessage);
 
         const createData = {
-            url: "/dialogs/SRP.html"
-        };
-        const creating = (browser as any).tabs.create(createData);
+                        type: "popup",
+                        url: "/dialogs/SRP.html",
+                        width: 700,
+                        height: 550
+                     };
+        const creating = (browser as any).windows.create(createData);
     }
 
     identifyToClient (password, s, B) {

--- a/dialogs/NetworkAuth.ts
+++ b/dialogs/NetworkAuth.ts
@@ -6,9 +6,9 @@ class NetworkAuth {
     }
 
     supplyNetworkAuth (loginIndex: number) {
-        (chrome as any).windows.getCurrent(win => {
+        (chrome as any).tabs.getCurrent(tab => {
             chrome.runtime.sendMessage({action: "NetworkAuth_ok", selectedLoginIndex: loginIndex });
-            const removing = (chrome as any).windows.remove(win.id);
+            const removing = (chrome as any).tabs.remove(tab.id);
         });
     }
 

--- a/dialogs/SRP.css
+++ b/dialogs/SRP.css
@@ -6,6 +6,11 @@ body {
     margin: 8px 0px;
 }
 
+.span-short {
+    max-width: 600px;
+    display: block;
+}
+
 .formSettingDropdown, .formSettingInput {
     margin-left: 10px;
     margin-right: 15px;
@@ -36,11 +41,12 @@ div.checkbox {
     grid-column-start: 1;
     justify-self: end;
     font-weight: initial;
-    max-width: 200px;
+    max-width: 220px;
 }
 
 .grid > .formSettingDropdown {
     grid-column-start: 2;
+    max-width: 220px;
 }
 
 .grid > .formSettingDescription {

--- a/dialogs/SRP.html
+++ b/dialogs/SRP.html
@@ -7,15 +7,15 @@
     <link rel="stylesheet" href="SRP.css"/>
     <title>Kee</title>
 </head>
-<body class="container-fluid">
+<body class="container">
     <div id="i18n_root" style="display:none">
         <form>
-            <div class="panel panel-default" id="panelAuth">
+            <div class="panel panel-primary panel-short" id="panelAuth">
                 <div class="panel-heading">
                     <h3 class="panel-title" data-i18n="conn_setup_enter_password_title"></h3>
                 </div>
                 <div class="panel-body">
-                    <div><span data-i18n="conn_setup_enter_password"></span></div>
+                    <div><span class="span-short" data-i18n="conn_setup_enter_password"></span></div>
                     <div class="form-horizontal">
                         <div class="form-group formSettingGroup">
                             <div class="formSettingLabel"><span data-i18n="password"></span></div>
@@ -27,8 +27,8 @@
                     </div>
                 </div>
             </div>
-
-            <div class="panel panel-default" id="panelSettings">
+            
+            <div class="panel panel-default panel-short" id="panelSettings">
                 <div class="panel-heading">
                     <h3 class="panel-title" data-i18n="pref_ConnectionSecurity_heading"></h3>
                 </div>
@@ -52,10 +52,10 @@
                 </div>
             </div>
 
-    <!-- We might have already connected at a lower security level but changing to a higher level here will cause the SRP negotiation to fail before the end -->
+            <!-- We might have already connected at a lower security level but changing to a higher level here will cause the SRP negotiation to fail before the end -->
 
             <div><a id="conn_sl_link" href="https://github.com/kee-org/KeeFox/wiki/en-%7C-Technical-%7C-KeePassRPC-%7C-Security-levels" target="_blank" data-i18n="conn_sl_link"></a></div>
-        </form>
+    </form>
     </div>
     <script src="../common/browser-polyfill.js"></script>
     <script src="../common/dollar-polyfill.js"></script>

--- a/dialogs/SRP.ts
+++ b/dialogs/SRP.ts
@@ -59,9 +59,9 @@ class SrpDialog {
     }
 
     continueSRP (password: string) {
-        (chrome as any).windows.getCurrent(win => {
+        (chrome as any).tabs.getCurrent(tab => {
             chrome.runtime.sendMessage({action: "SRP_ok", password: password });
-            const removing = (chrome as any).windows.remove(win.id);
+            const removing = (chrome as any).tabs.remove(tab.id);
         });
     }
 }


### PR DESCRIPTION
I was strongly surprised when Chrome closed silently after I entered Kee Authorisation password and clicked Connect button.
After some investigation I found that the extension closes current window after successful connection to KeePass. In this case I have the OneWindow extension installed in Chrome and all windows opened by the extension turn into tabs of single window and exactly this window was closed by the extension.
Solution: replace window opening to tab opening.

Link to OneWindow extension I used: [OneWindow](https://chrome.google.com/webstore/detail/one-window/papnlnnbddhckngcblfljaelgceffobn?utm_source=chrome-app-launcher-info-dialog)