### PR TITLE
Define panels font color as black in panels css.

### DIFF
--- a/panels/panels.css
+++ b/panels/panels.css
@@ -7,6 +7,7 @@ body {
 
 body {
     background-color: white;
+    color: #000000;
     padding: 0px;
     margin: 0px;
     height: 100vh;
@@ -60,7 +61,6 @@ body {
     line-height:26px;
     position:relative;
     background-color: #FFFFFF;
-    color: #000000;
     border: 1px solid #FFFFFF;
 }
 

--- a/panels/panels.css
+++ b/panels/panels.css
@@ -60,6 +60,7 @@ body {
     line-height:26px;
     position:relative;
     background-color: #FFFFFF;
+    color: #000000;
     border: 1px solid #FFFFFF;
 }
 


### PR DESCRIPTION
Fixes text visibility for those who have defined their default font color as something bright/white.
This is a huge problem for me, since I can never see what account I'm trying to select.

I asked about this on the forum quite a long time ago, and got no replies ( [link](https://forum.kee.pm/t/firefox-addon-password-suggestion-text-color-issue/1163) ), so I decided to see if I could fix it.

Please tell me if I did something wrong, haven't really contributed that much ^^".