### PR TITLE
Fix extension error when form contains elements with name set to "id" or "name"

### DIFF
--- a/common/ConfigManager.ts
+++ b/common/ConfigManager.ts
@@ -576,8 +576,8 @@ export class ConfigManager {
         const fieldNames = otherFields
             .map(field => (ic ? field.locators[0]?.name.toLowerCase() : field.locators[0]?.name))
             .filter(Boolean);
-        const formId = ic ? form.id?.toLowerCase() : form.id;
-        const formName = ic ? form.name?.toLowerCase() : form.name;
+        const formId = ic ? form.getAttribute('id')?.toLowerCase() : form.getAttribute('id');
+        const formName = ic ? form.getAttribute('name')?.toLowerCase() : form.getAttribute('name');
         const excludeFormIds = (conf?.blackList?.form?.ids || [])
             .map(x => (ic ? x?.toLowerCase() : x))
             .filter(Boolean);

--- a/common/ConfigManager.ts
+++ b/common/ConfigManager.ts
@@ -567,7 +567,7 @@ export class ConfigManager {
         });
         return derivedConfig;
     }
-    
+
     private normalizeFormProperty(input: unknown, ic: boolean) {
         if (typeof input !== "string") return null;
         return ic ? stringInput.toLowerCase() : stringInput;
@@ -581,8 +581,8 @@ export class ConfigManager {
         const fieldNames = otherFields
             .map(field => (ic ? field.locators[0]?.name.toLowerCase() : field.locators[0]?.name))
             .filter(Boolean);
-        const formId = this.normalizeStringFormProperty(form.id, ic);
-        const formName = this.normalizeStringFormProperty(form.name, ic);
+        const formId = this.normalizeFormProperty(form.id, ic);
+        const formName = this.normalizeFormProperty(form.name, ic);
         const excludeFormIds = (conf?.blackList?.form?.ids || [])
             .map(x => (ic ? x?.toLowerCase() : x))
             .filter(Boolean);

--- a/common/ConfigManager.ts
+++ b/common/ConfigManager.ts
@@ -576,8 +576,8 @@ export class ConfigManager {
         const fieldNames = otherFields
             .map(field => (ic ? field.locators[0]?.name.toLowerCase() : field.locators[0]?.name))
             .filter(Boolean);
-        const formId = ic ? form.getAttribute('id')?.toLowerCase() : form.getAttribute('id');
-        const formName = ic ? form.getAttribute('name')?.toLowerCase() : form.getAttribute('name');
+        const formId = ic ? form.getAttribute("id")?.toLowerCase() : form.getAttribute("id");
+        const formName = ic ? form.getAttribute("name")?.toLowerCase() : form.getAttribute("name");
         const excludeFormIds = (conf?.blackList?.form?.ids || [])
             .map(x => (ic ? x?.toLowerCase() : x))
             .filter(Boolean);

--- a/common/ConfigManager.ts
+++ b/common/ConfigManager.ts
@@ -567,6 +567,11 @@ export class ConfigManager {
         });
         return derivedConfig;
     }
+    
+    private normalizeFormProperty(input: unknown, ic: boolean) {
+        if (typeof input !== "string") return null;
+        return ic ? stringInput.toLowerCase() : stringInput;
+    }
 
     public isFormInteresting(form: HTMLFormElement, conf: SiteConfig, otherFields: Field[]) {
         const ic = conf.listMatchingCaseSensitive !== true;
@@ -576,8 +581,8 @@ export class ConfigManager {
         const fieldNames = otherFields
             .map(field => (ic ? field.locators[0]?.name.toLowerCase() : field.locators[0]?.name))
             .filter(Boolean);
-        const formId = ic ? form.getAttribute("id")?.toLowerCase() : form.getAttribute("id");
-        const formName = ic ? form.getAttribute("name")?.toLowerCase() : form.getAttribute("name");
+        const formId = this.normalizeStringFormProperty(form.id, ic);
+        const formName = this.normalizeStringFormProperty(form.name, ic);
         const excludeFormIds = (conf?.blackList?.form?.ids || [])
             .map(x => (ic ? x?.toLowerCase() : x))
             .filter(Boolean);

--- a/common/ConfigManager.ts
+++ b/common/ConfigManager.ts
@@ -570,7 +570,7 @@ export class ConfigManager {
 
     private normalizeFormProperty(input: unknown, ic: boolean) {
         if (typeof input !== "string") return null;
-        return ic ? stringInput.toLowerCase() : stringInput;
+        return ic ? input.toLowerCase() : input;
     }
 
     public isFormInteresting(form: HTMLFormElement, conf: SiteConfig, otherFields: Field[]) {


### PR DESCRIPTION
Fixes extension error when form contains elements with `name` attribute set to "id" or "name". See https://github.com/kee-org/browser-addon/issues/297#issuecomment-772832415, https://forum.kee.pm/t/kee-browser-extension-bug-using-form-name-rather-than-form-getattribute-name/3503/3 and https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/name

Bug introduced in https://github.com/kee-org/browser-addon/commit/21efb9d5baccc90f9cce11cdfca24161a08867e2#diff-28be9268beaee14e36d782ac5832cab19593348724c0caf74b2d79c0d349257eR454-R455

Fixes #297
